### PR TITLE
Document `-[PF_Twitter init]`, and, add method to invalidate an OAuth token

### DIFF
--- a/ParseTwitterUtils/PF_Twitter.h
+++ b/ParseTwitterUtils/PF_Twitter.h
@@ -22,6 +22,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PF_Twitter : NSObject
 
 /**
+ An instance of `PF_Twitter` configured to access device Twitter accounts with Accounts.framework,
+ and remote Twitter accounts - if no accounts are found locally - through a built-in webview.
+
+ After setting `consumerKey` and `consumerSecret`, authorization to Twitter accounts can be requested with
+`authorizeInBackground`, and then revoked with its opposite, `deauthorizeInBackground`.
+ */
+- (instancetype)init;
+
+/**
  Consumer key of the application that is used to authorize with Twitter.
  */
 @property (nullable, nonatomic, copy) NSString *consumerKey;

--- a/ParseTwitterUtils/PF_Twitter.h
+++ b/ParseTwitterUtils/PF_Twitter.h
@@ -69,6 +69,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BFTask *)authorizeInBackground;
 
 /**
+ Invalidates an OAuth token for the current user, if the Twitter user has granted permission to the
+ current application.
+
+ @return The task, that encapsulates the work being done.
+ */
+- (BFTask *)deauthorizeInBackground;
+
+/**
  Displays an auth dialog and populates the authToken, authTokenSecret, userId, and screenName properties
  if the Twitter user grants permission to the application.
 

--- a/ParseTwitterUtils/PF_Twitter.m
+++ b/ParseTwitterUtils/PF_Twitter.m
@@ -92,6 +92,30 @@
         return source.task;
     }];
 }
+- (BFTask *)deauthorizeInBackground {
+    if (self.consumerKey.length == 0 || self.consumerSecret.length == 0) {
+        //TODO: (nlutsenko) This doesn't look right, maybe we should add additional error code?
+        return [BFTask taskWithError:[NSError errorWithDomain:PFParseErrorDomain code:1 userInfo:nil]];
+    }
+
+    return [[self _performDeauthAsync] pftw_continueAsyncWithBlock:^id(BFTask *task) {
+        BFTaskCompletionSource *source = [BFTaskCompletionSource taskCompletionSource];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (task.cancelled) {
+                [source cancel];
+            } else if (!task.error && !task.result) {
+                source.result = nil;
+            } else if (task.error) {
+                [source trySetError:task.error];
+            } else if (task.result) {
+                [self setLoginResultValues:@{}];
+
+                [source trySetResult:task.result];
+            }
+        });
+        return source.task;
+    }];
+}
 
 - (void)authorizeWithSuccess:(void (^)(void))success
                      failure:(void (^)(NSError *error))failure
@@ -426,6 +450,26 @@
     }];
 
     return source.task;
+}
+
+- (BFTask *)_performDeauthAsync {
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
+    request.URL = [NSURL URLWithString:@"https://api.twitter.com/oauth2/invalidate_token"];
+    request.HTTPMethod = @"POST";
+
+    [self signRequest:request];
+
+    BFTaskCompletionSource *taskCompletionSource = [BFTaskCompletionSource taskCompletionSource];
+
+    [[self.urlSession dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (error) {
+            [taskCompletionSource trySetError:error];
+        } else {
+            [taskCompletionSource trySetResult:data];
+        }
+    }] resume];
+
+    return taskCompletionSource.task;
 }
 
 ///--------------------------------------


### PR DESCRIPTION
Unsure if the tests pass because I couldn't get them to run locally, but, the file compiles.